### PR TITLE
Fix webInterface section in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ Kelvin will create it's configuration file `config.json` in the current director
     "latitude": 53.5553,
     "longitude": 9.995
   },
+  "webInterface": {
+    "enabled": false,
+    "port": 8080
+  },
   "schedules": [
     {
       "name": "default",

--- a/configuration.go
+++ b/configuration.go
@@ -74,7 +74,7 @@ type Configuration struct {
 	Version           int             `json:"version"`
 	Bridge            Bridge          `json:"bridge"`
 	Location          Location        `json:"location"`
-	WebInterface      WebInterface    `json:"webinterface"`
+	WebInterface      WebInterface    `json:"webInterface"`
 	Schedules         []LightSchedule `json:"schedules"`
 }
 


### PR DESCRIPTION
Prior to this commit, the default configuration would place
a "webinterface" section in the configuration file.  But
that didn't do anything because Interface needed to be capitalized.

After this commit, we make sure the webInterface section has correct
capitalization so it is read on startup.