### PR TITLE
XY Color change now triggers hasChanged true

### DIFF
--- a/huelight.go
+++ b/huelight.go
@@ -170,7 +170,7 @@ func (light *HueLight) setLightState(colorTemperature int, brightness int, trans
 
 func (light *HueLight) hasChanged() bool {
 	if light.SupportsXYColor && light.CurrentColorMode == "xy" {
-		if !equalsFloat(light.TargetColor, []float32{-1, -1}, 0) && !equalsFloat(light.TargetColor, light.CurrentColor, 0.001) {
+		if !equalsFloat(light.TargetColor, []float32{-1, -1}, 0.0000000000000001) && !equalsFloat(light.TargetColor, light.CurrentColor, 0.001) {
 			log.Debugf("💡 HueLight %s - Color has changed! CurrentColor: %v, TargetColor: %v (%dK)", light.Name, light.CurrentColor, light.TargetColor, light.SetColorTemperature)
 			return true
 		}


### PR DESCRIPTION
Since equalsFloat divides by the maxDiff parameter I'm not sure the first condition can ever be true since that would be division by zero?  When changing the xy color of my lights they were always reverted instead of realizing a change had occurred.  

https://github.com/stefanwichmann/kelvin/blob/75031004406831911547dcedd1fa894554a9df76/util.go#L77

Using this patch, Kelvin correctly realizes that the xy color has changed and does not change them back to the schedule.  