### PR TITLE
Allow compiling for a single platform

### DIFF
--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -euo pipefail
-IFS=$"\\n\\t"
 
 # constants
 BINARY_NAME="kelvin"
@@ -76,6 +75,9 @@ buildTarget() {
 
 # MAIN
 echo Start
+if [ "$#" -eq 2 ]; then
+    buildTarget $1 $2
+else
 buildTarget linux amd64
 buildTarget linux 386
 buildTarget linux arm
@@ -83,4 +85,5 @@ buildTarget freebsd amd64
 buildTarget darwin amd64
 buildTarget windows amd64
 buildTarget windows 386
+fi
 echo Done


### PR DESCRIPTION
Prior to this commit, you could only use the dist.sh script
to build all available platforms.

After this commit, you can pass a specific platform and
architecture to the script to build just what you are currently
testing on.