### PR TITLE
Modified .travis.yml to build for multiple architectures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ go:
 services:
   - docker
 
+  env:
+    global:
+      - DOCKER_CLI_EXPERIMENTAL=enabled
+      - PLATFORMS=linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
+
 before_script:
   - go get
   - go vet ./...
@@ -33,6 +38,7 @@ deploy:
     tags: true
 
 after_deploy:
-  - docker build -t stefanwichmann/kelvin .
+  - docker buildx create --use
+  - docker buildx build --platform $PLATFORMS -t stefanwichmann/kelvin .
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   - docker push stefanwichmann/kelvin


### PR DESCRIPTION
I'd love to be able to run Kelvin inside a Docker container on my Pi. 

Currently, in Travis, Docker is only building an image for the AMD64 architecture. This PR uses Docker's experimental command line options (more info [here](https://www.docker.com/blog/multi-arch-images/)) to build the image for ARM as well.

I'm pretty sure this will work, but please let me know if you have any issues or concerns, and I'll try to get them resolved. Thanks!