### PR TITLE
Add a list of models which don't support XY color.

### DIFF
--- a/huelight.go
+++ b/huelight.go
@@ -34,6 +34,9 @@ var lightsSupportingDimming = []string{"Dimmable light", "Color temperature ligh
 var lightsSupportingColorTemperature = []string{"Color temperature light", "Extended color light"}
 var lightsSupportingXYColor = []string{"Color light", "Extended color light"}
 
+// These models say they support XY color, but it doesn't work correctly
+var modelsNotSupportingXYColor = []string{"GL-B-008Z"}
+
 // HueLight represents a physical hue light.
 type HueLight struct {
 	Name                     string
@@ -60,7 +63,7 @@ func (light *HueLight) initialize(attr hue.LightAttributes) {
 	light.Name = attr.Name
 	light.Dimmable = containsString(lightsSupportingDimming, attr.Type)
 	light.SupportsColorTemperature = containsString(lightsSupportingColorTemperature, attr.Type)
-	light.SupportsXYColor = containsString(lightsSupportingXYColor, attr.Type)
+	light.SupportsXYColor = containsString(lightsSupportingXYColor, attr.Type) && !containsString(modelsNotSupportingXYColor, attr.ModelId)
 
 	// set minimum color temperature depending on type
 	if attr.Type == "Color temperature light" {


### PR DESCRIPTION
This works around models which say they support XY color, but do it incorrectly.

I have two [Gledopto white/color bulbs](https://www.aliexpress.com/item/32929637739.html). When I try to use them with mainline kelvin, during daytime they get set to a dim, relatively saturated color. It appears that they don't support XY color mode correctly. This change adds a list of light model IDs to never use with XY color.

I'm not sure if this is the right approach - it might be possible to infer this from the light properties. However, I'm pretty sure this change won't break anything. Here's the info on the bulb I have:

```
{
	"state": {
		"on": true,
		"bri": 254,
		"hue": 34560,
		"sat": 17,
		"effect": "none",
		"xy": [
			0.322,
			0.338
		],
		"ct": 166,
		"alert": "none",
		"colormode": "ct",
		"mode": "homeautomation",
		"reachable": true
	},
	"swupdate": {
		"state": "notupdatable",
		"lastinstall": null
	},
	"type": "Extended color light",
	"name": "Adam color",
	"modelid": "GL-B-008Z",
	"manufacturername": "GLEDOPTO",
	"productname": "Extended color light",
	"capabilities": {
		"certified": false,
		"control": {
			"colorgamuttype": "other",
			"ct": {
				"min": 0,
				"max": 65535
			}
		},
		"streaming": {
			"renderer": false,
			"proxy": false
		}
	},
	"config": {
		"archetype": "classicbulb",
		"function": "mixed",
		"direction": "omnidirectional"
	},
	"uniqueid": "00:12:4b:00:1a:06:98:03-0b",
	"swversion": "1.0.3"
}
```