### PR TITLE
Update Readme to current release for pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ There are a couple assumptions made:
 ## Setup
 ```shell
 # Fetch release
-wget https://github.com/stefanwichmann/kelvin/releases/download/v1.1.9/kelvin-linux-arm-v1.1.9.tar.gz -O /tmp/kelvin-arm.tar.gz
+wget https://github.com/stefanwichmann/kelvin/releases/download/v1.3.2/kelvin-linux-arm-v1.3.2.tar.gz -O /tmp/kelvin-arm.tar.gz
 
 # Create user to run as
 sudo adduser --system --group --shell /bin/nologin --no-create-home --home /opt/kelvin kelvin


### PR DESCRIPTION
Updated wget command in readme under pi instructions to use 1.3.2 as the current listed build fails to start due to errors in the service config