### PR TITLE
Fixed a bug in equalsFloat when maxDiff = 0.

### DIFF
--- a/util.go
+++ b/util.go
@@ -74,6 +74,15 @@ func equalsFloat(a []float32, b []float32, maxDiff float32) bool {
 		return false
 	}
 	for index := 0; index < len(a); index++ {
+	        if maxDiff == 0 {
+		        // Special case to prevent 'rounded' from becoming NaN
+			// below and therefore 'rounded > maxDiff' always being
+			// false.
+		        if a[index] != b[index] {
+			        return false
+			}
+			continue
+		}
 		rounded := float32(math.Round(math.Abs(float64(a[index]-b[index]))/float64(maxDiff))) * maxDiff
 		if rounded > maxDiff {
 			return false

--- a/util_test.go
+++ b/util_test.go
@@ -48,6 +48,11 @@ func TestEqualsFloat(t *testing.T) {
 	}
 
 	// Should not be equal
+	equal = equalsFloat([]float32{0.5, 0.5}, []float32{-1, -1}, 0)
+	if equal {
+		t.Errorf("equalsFloat([]float32{0.5, 0.5}, []float32{-1, -1}, 0) = %t; want false", equal)
+	}
+
 	equal = equalsFloat([]float32{-1}, []float32{-1, -1}, 0)
 	if equal {
 		t.Errorf("equalsFloat([]float32{-1}, []float32{-1, -1}, 0) = %t; want false", equal)


### PR DESCRIPTION
It was always returning false due to 'rounded' being NaN.
The consequence was that 'hasChanged' in huelight was always returning
false when the light was in xy color mode, so manual color changes
were not detected. Color temperature changes were correctly detected,
which is probably the reason why this bug was not found earlier.