### PR TITLE
Makes schedules.html tables mobile-friendly.

### DIFF
--- a/gui/static/css/kelvin.css
+++ b/gui/static/css/kelvin.css
@@ -1,3 +1,9 @@
 body {
   padding-top: 50px;
 }
+
+@media (max-width: 767px) {
+  .deleteschedule {
+    padding-top: 20px;
+  }
+}

--- a/gui/template/schedules.html
+++ b/gui/template/schedules.html
@@ -70,68 +70,74 @@
               <input type="checkbox" class="appearBehavior form-check-input" {{if .EnableWhenLightsAppear}}checked{{end}} autocomplete="off">
             </div>
           </form>
-          <div class="subschedule">
+          <div class="subschedule row">
             <h1>Morning <small>(00:00 - sunrise)</small></h1>
-            <table class="beforeSunrise table">
-              <tr><th class="col-md-2">Time</th><th class="col-md-4">Color Temperature</th><th class="col-md-4">Brightness</th><th class="col-md-2">Control</th></tr>
-              {{range .BeforeSunrise}}
-              <tr class="entry">
-                <td><input type="time" name="time" class="time form-control" value="{{.Time}}" autocomplete="off"></td>
-                <td><input type="number" name="colorTemperature" class="colorTemperature form-control" value="{{.ColorTemperature}}" min="0" max="6500" autocomplete="off"></td>
-                <td><input type="range" name="brightness" class="brightness form-control" value="{{.Brightness}}" min="0" max="100" autocomplete="off"></td>
-                <td>
-                  <div class="btn-group">
-                    <button type="button" class="deleteEntryButton btn btn-primary">Delete</button>
-                    <button type="button" class="testEntryButton btn btn-primary">Test</button>
-                  </div>
-                </td>
-              </tr>
-              {{end}}
-            </table>
-            <div class="text-center">
+            <div class="table-responsive">
+              <table class="beforeSunrise table">
+                <tr><th class="col-md-2">Time</th><th class="col-md-4">Color Temperature</th><th class="col-md-4">Brightness</th><th class="col-md-2">Control</th></tr>
+                {{range .BeforeSunrise}}
+                <tr class="entry">
+                  <td><input type="time" name="time" class="time form-control" value="{{.Time}}" autocomplete="off"></td>
+                  <td><input type="number" name="colorTemperature" class="colorTemperature form-control" value="{{.ColorTemperature}}" min="0" max="6500" autocomplete="off"></td>
+                  <td><input type="range" name="brightness" class="brightness form-control" value="{{.Brightness}}" min="0" max="100" autocomplete="off"></td>
+                  <td>
+                    <div class="btn-group">
+                      <button type="button" class="deleteEntryButton btn btn-primary">Delete</button>
+                      <button type="button" class="testEntryButton btn btn-primary">Test</button>
+                    </div>
+                  </td>
+                </tr>
+                {{end}}
+              </table>
+            </div>
+            <div class="row text-center">
               <button type="button" class="addEntryButton btn btn-primary">Add entry</button>
             </div>
           </div>
-          <div class="subschedule">
+          <div class="subschedule row">
             <h1>Daylight <small>(sunrise - sunset)</small></h1>
-            <table class="default table">
-              <tr><th class="col-md-2">Time</th><th class="col-md-4">Color Temperature</th><th class="col-md-4">Brightness</th><th class="col-md-2">Control</th></tr>
-              <tr class="entry">
-                <td><input type="text" name="time" class="text form-control" value="sunrise - sunset" disabled></td>
-                <td><input type="number" name="colorTemperature" class="colorTemperature form-control" value="{{.DefaultColorTemperature}}" min="0" max="6500" autocomplete="off"></td>
-                <td><input type="range" name="brightness" class="brightness form-control" value="{{.DefaultBrightness}}" min="0" max="100" autocomplete="off"></td>
-                <td>
-                  <div class="btn-group">
-                    <button type="button" class="deleteEntryButton btn btn-primary" disabled>Delete</button>
-                    <button type="button" class="testEntryButton btn btn-primary">Test</button>
-                  </div>
-                </td>
-              </tr>
-            </table>
+            <div class="table-responsive">
+              <table class="default table">
+                <tr><th class="col-md-2">Time</th><th class="col-md-4">Color Temperature</th><th class="col-md-4">Brightness</th><th class="col-md-2">Control</th></tr>
+                <tr class="entry">
+                  <td><input type="text" name="time" class="text form-control" value="sunrise - sunset" disabled></td>
+                  <td><input type="number" name="colorTemperature" class="colorTemperature form-control" value="{{.DefaultColorTemperature}}" min="0" max="6500" autocomplete="off"></td>
+                  <td><input type="range" name="brightness" class="brightness form-control" value="{{.DefaultBrightness}}" min="0" max="100" autocomplete="off"></td>
+                  <td>
+                    <div class="btn-group">
+                      <button type="button" class="deleteEntryButton btn btn-primary" disabled>Delete</button>
+                      <button type="button" class="testEntryButton btn btn-primary">Test</button>
+                    </div>
+                  </td>
+                </tr>
+              </table>
+            </div>
           </div>
-          <div class="subschedule">
+          <div class="subschedule row">
             <h1>Evening <small>(sunset - 23:59)</small></h1>
-            <table class="afterSunset table">
-              <tr><th class="col-md-2">Time</th><th class="col-md-4">Color Temperature</th><th class="col-md-4">Brightness</th><th class="col-md-2">Control</th></tr>
-              {{range .AfterSunset}}
-              <tr class="entry">
-                <td><input type="time" name="time" class="time form-control" value="{{.Time}}" autocomplete="off"></td>
-                <td><input type="number" name="colorTemperature" class="colorTemperature form-control" value="{{.ColorTemperature}}" min="0" max="6500" autocomplete="off"></td>
-                <td><input type="range" name="brightness" class="brightness form-control" value="{{.Brightness}}" min="0" max="100" autocomplete="off"></td>
-                <td>
-                  <div class="btn-group">
-                    <button type="button" class="deleteEntryButton btn btn-primary">Delete</button>
-                    <button type="button" class="testEntryButton btn btn-primary">Test</button>
-                  </div>
-                </td>
-              </tr>
-              {{end}}
-            </table>
-            <div class="text-center">
+            <div class="table-responsive">
+              <table class="afterSunset table">
+                <tr><th class="col-md-2">Time</th><th class="col-md-4">Color Temperature</th><th class="col-md-4">Brightness</th><th class="col-md-2">Control</th></tr>
+                {{range .AfterSunset}}
+                <tr class="entry">
+                  <td><input type="time" name="time" class="time form-control" value="{{.Time}}" autocomplete="off"></td>
+                  <td><input type="number" name="colorTemperature" class="colorTemperature form-control" value="{{.ColorTemperature}}" min="0" max="6500" autocomplete="off"></td>
+                  <td><input type="range" name="brightness" class="brightness form-control" value="{{.Brightness}}" min="0" max="100" autocomplete="off"></td>
+                  <td>
+                    <div class="btn-group">
+                      <button type="button" class="deleteEntryButton btn btn-primary">Delete</button>
+                      <button type="button" class="testEntryButton btn btn-primary">Test</button>
+                    </div>
+                  </td>
+                </tr>
+                {{end}}
+              </table>
+            </div>
+            <div class="row text-center">
               <button type="button" class="addEntryButton btn btn-primary">Add entry</button>
             </div>
           </div>
-          <div class="text-right">
+          <div class="deleteschedule row text-right">
             <button type="button" class="deleteScheduleButton btn btn-danger">Delete schedule</button>
           </div>
         </div>


### PR DESCRIPTION
Wraps `subschedule` tables in a `.table-responsive` div to make tables mobile-friendly. 

Also adds a little extra `padding-top` to the "delete schedule" button, to separate it from the "add entry" button from evening schedule. 

## Mobile
+ at head: 
  + ![head1](https://user-images.githubusercontent.com/1364489/154874672-3071aa98-b253-4396-b896-c785914dede6.png)
  + ![head2](https://user-images.githubusercontent.com/1364489/154874665-1fba5b87-6d8e-4d7b-b625-f17324a3f849.png)
+ PR:
  + ![fixmobile1](https://user-images.githubusercontent.com/1364489/154874669-e6ce5134-a4e9-4a30-9145-ac05704900b3.PNG)
  + ![fixmobile2](https://user-images.githubusercontent.com/1364489/154874671-c4b4d71e-6095-4709-9556-c20e9396344b.png)

## Desktop
+ Minimal changes, mostly aligning schedules. 
+ at head: 
  + ![head_desktop](https://user-images.githubusercontent.com/1364489/154874673-d2fb419e-f37a-4749-b4a2-3036fd8d6d5c.PNG)
+ PR:
  + ![fixmobile_desktop](https://user-images.githubusercontent.com/1364489/154874667-03b6e61c-9071-418e-9f3f-8b5f9068c5d1.png)